### PR TITLE
whitetify headings

### DIFF
--- a/cosmos/static/cosmos/css/core.css
+++ b/cosmos/static/cosmos/css/core.css
@@ -8,12 +8,15 @@ body {
     background: #dfdfdf;
 }
 
+h1, h2, h3, h4, h5, h6, p {
+    color: #ccc;
+}
+
 p {
     font-family: 'Poppins', sans-serif;
     font-size: 1.1em;
     font-weight: 300;
     line-height: 1.7em;
-    color: #ccc;
 }
 
 a,


### PR DESCRIPTION
smh