### PR TITLE
Fix reverse url for profile

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -64,22 +64,22 @@ def profile(request):
                 user_form.save()
                 profile_form.save()
                 messages.success(request, "Your profile was successfully updated!")
-                return redirect(reverse("user_profile") + "#profile")
+                return redirect(reverse("cosmos_users:user_profile") + "#profile")
         elif "save_password" in request.POST:
             if password_form.is_valid():
                 password_form.save()
                 messages.success(request, "Your password was succesfully updated!")
-                return redirect(reverse("user_profile") + "#password")
+                return redirect(reverse("cosmos_users:user_profile") + "#password")
         elif "save_preferences" in request.POST:
             if profile_form.is_valid():
                 profile_form.save()
                 messages.success(request, "Your preferences were succesfully updated!")
-                return redirect(request("user_profile") + "#preferences")
+                return redirect(request("cosmos_users:user_profile") + "#preferences")
         elif "save_key_access" in request.POST:
             if profile_form.is_valid():
                 profile_form.save()
                 messages.success(request, "Your key access settings were succesfully updated!")
-                return redirect(reverse("user_profile") + "#key-access")
+                return redirect(reverse("cosmos_users:user_profile") + "#key-access")
 
         if user_form.is_valid() and profile_form.is_valid():
             user_form.save()


### PR DESCRIPTION
Fixes the reverse urls in the profile view, that were changed with the urlconf changes.

## Description
Added the urlconf namespace before the url to be reversed.

## Motivation and Context
Caused a server 500 error previously on saving preferences.

## How Has This Been Tested?
Manually, unit tests need to be developed in general for all views.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
