### PR TITLE
change navbar filler height to rem instead of a calc

### DIFF
--- a/cosmos/static/cosmos/css/core.css
+++ b/cosmos/static/cosmos/css/core.css
@@ -82,7 +82,7 @@ a:hover {
 }
 
 .navbar-filler {
-    height: calc(72px + 1rem);
+    height: 4.5rem;
 }
 
 .footer-filler {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`.navbar-filler` didn't work in a production environment due to uglify removing spaces and breaking `calc()`
