### PR TITLE
Add dev requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,17 @@
+##################
+#    Linting     #
+##################
+flake8
+flake8-django
+pep8-naming
+flake8-isort
+
+##################
+#   Formatting   #
+##################
+black
+
+##################
+#    Testing     #
+##################
+tox


### PR DESCRIPTION
Add dev requirements to file, allowing for `pip install -r dev_requirements.txt` to install all development requirements.