### PR TITLE
Fix password reset link + view

### DIFF
--- a/apps/users/forms/auth.py
+++ b/apps/users/forms/auth.py
@@ -118,5 +118,5 @@ class CosmosSetPasswordForm(SetPasswordForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
-        self.helper.form_tage = False
+        self.helper.form_tag = False
         self.helper.layout = Layout(FloatingField())

--- a/apps/users/templates/registration/password_reset_email.html
+++ b/apps/users/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 {% translate "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
-    <a href="{{ protocol }}://{{ domain }}{% url 'cosmos_users:password_reset_confirm' uidb64=uid token=token %}">{{ protocol }}://{{ domain }}{% url 'cosmos_users:password_reset_confirm' uidb64=uid token=token %}</a>
+{{ protocol }}://{{ domain }}{% url 'cosmos_users:password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}
 {% translate 'Your username, in case you’ve forgotten:' %} {{ user.get_username }}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
The link in the password reset email became wonky due to it being replaced with safelinks, and the view had the form tag still being put in due to a typo, therefore being unsubmittable, this should fix it.

<!--- Add linked issue here if applicable -->
Fixes #

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
