### PR TITLE
Fix card height issues

### DIFF
--- a/cosmos/static/cosmos/css/core.css
+++ b/cosmos/static/cosmos/css/core.css
@@ -69,6 +69,11 @@ a:hover {
     border-color: var(--blue);
 }
 
+.btn-over-stretched {
+    z-index: 2;
+    position: relative;
+}
+
 .home-img {
     position: relative;
     width: 100%;

--- a/cosmos/templates/news/news_list.html
+++ b/cosmos/templates/news/news_list.html
@@ -21,22 +21,19 @@
         {% for news in news_list %}
             <div class="col">
                 <div class="card h-100{% if not news.published %} news-disabled{% endif %}">
-                    {# transform is added so that stretched link does not go into footer #}
-                    <div style="transform: rotate(0);">
-                        <img class="card-img-top news-image" src="{{ news.image.url }}">
-                        <div class="card-body">
-                            <h5 class="card-title">{{ news.title }}</h5>
-                            <p class="news-truncate">{{ news.lead }}</p>
-                            <a class="stretched-link" href="{% url 'news-view' news.id %}"></a>
-                        </div>
+                    <img class="card-img-top news-image" src="{{ news.image.url }}">
+                    <div class="card-body">
+                        <h5 class="card-title">{{ news.title }}</h5>
+                        <p class="news-truncate">{{ news.lead }}</p>
+                        <a class="stretched-link" href="{% url 'news-view' news.id %}"></a>
                     </div>
                     <div class="card-footer">
                         {% if perms.cosmos.change_news and perms.cosmos.delete_news %}
                         <div class="float-end">
-                            <a class="btn p-0" href="{% url 'news-update' news.id %}">
+                            <a class="btn p-0 btn-over-stretched" href="{% url 'news-update' news.id %}">
                                 <i class="bi bi-pencil-square"></i>
                             </a>
-                            <a class="btn p-0" href="{% url 'news-delete' news.id %}">
+                            <a class="btn p-0 btn-over-stretched" href="{% url 'news-delete' news.id %}">
                                 <i class="bi bi-trash"></i>
                             </a>
                         </div>

--- a/cosmos/templates/photo_album/photo_album_view.html
+++ b/cosmos/templates/photo_album/photo_album_view.html
@@ -29,12 +29,10 @@
             {% for photo_object in album.has_photos.all %}
             <div class="col">
                 <div class="card">
-                    <div style="transform: rotate(0);">
-                        <img src="{{ photo_object.photo.url }}" class="card-img-top album-image" loading="lazy">
-                        <a class="stretched-link" href="#" data-bs-toggle="modal" data-bs-target="#photoModal" data-bs-image-url="{{ photo_object.photo.url }}"></a>
-                    </div>
+                    <img src="{{ photo_object.photo.url }}" class="card-img-top album-image" loading="lazy">
+                    <a class="stretched-link" href="#" data-bs-toggle="modal" data-bs-target="#photoModal" data-bs-image-url="{{ photo_object.photo.url }}"></a>
                     {% if perms.cosmos.delete_photoobject %}
-                    <a href="{% url 'photo_object-delete' photo_object.id %}" class="photo-delete">
+                    <a href="{% url 'photo_object-delete' photo_object.id %}" class="photo-delete btn-over-stretched">
                         <i class="bi bi-trash"></i>
                     </a>
                     {% endif %}

--- a/tests/cosmos/views/news.py
+++ b/tests/cosmos/views/news.py
@@ -189,12 +189,18 @@ class NewsListViewTest(TestCase):
             self.assertIsNotNone(output)
 
         if can_change:
-            self.assertEqual(f"/news/{news.pk}/update/", news_object.find_all("a", {"class": "btn p-0"})[0].get("href"))
+            self.assertEqual(
+                f"/news/{news.pk}/update/",
+                news_object.find_all("a", {"class": "btn p-0 btn-over-stretched"})[0].get("href"),
+            )
         else:
             self.assertIsNone(news_object.find("a", {"class": "btn p-0", "href": f"/news/{news.pk}/update/"}))
 
         if can_delete:
-            self.assertEqual(f"/news/{news.pk}/delete/", news_object.find_all("a", {"class": "btn p-0"})[1].get("href"))
+            self.assertEqual(
+                f"/news/{news.pk}/delete/",
+                news_object.find_all("a", {"class": "btn p-0 btn-over-stretched"})[1].get("href"),
+            )
         else:
             self.assertIsNone(news_object.find("a", {"class": "btn p-0", "href": f"/news/{news.pk}/delete/"}))
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Caused by rotate(0) which was necessary to show buttons over a stretched link, using an alternate solution now that also only just makes the buttons on top, and not the whole footer.

<!--- Add linked issue here if applicable -->
Fixes #

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
