### PR TITLE
Make sure datetimes are timezone aware

### DIFF
--- a/apps/events/templates/events/event_view.html
+++ b/apps/events/templates/events/event_view.html
@@ -27,8 +27,8 @@
                 {% endif %}
                 <h4 class="card-title">{{ event.name }}</h4>
                 <ul class="event-details">
-                    <li><b>From: </b>{{ event.start_date_time.date }}, <em>{{ event.start_date_time.time }}</em></li>
-                    <li><b>To:   </b>{{ event.end_date_time.date }}, <em>{{ event.end_date_time.time }}</em></li>
+                    <li><b>From: </b>{{ event.start_date_time|date }}, <em>{{ event.start_date_time|time }}</em></li>
+                    <li><b>To:   </b>{{ event.end_date_time|date }}, <em>{{ event.end_date_time|time }}</em></li>
                     <li><b>Where: </b>{{ event.location }}</li>
                     <li><b>Cost:  </b>{% if not event.price %} Free {% else %} {{ event.price }} € {% endif %}</li>
                 </ul>

--- a/tests/events/views/events.py
+++ b/tests/events/views/events.py
@@ -3,6 +3,8 @@ from bs4 import BeautifulSoup
 from django.contrib.auth.models import Group, Permission, User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+from django.utils.timezone import make_aware
+import datetime
 
 from apps.events.errors import END_DATE_BEFORE_START
 from apps.events.forms import EventForm
@@ -61,8 +63,8 @@ class EventsViewTest(TestCase):
             image=get_image_file(),
             description="Public Event description",
             lead="Public Event Lead",
-            start_date_time="2200-01-01 01:20",
-            end_date_time="2200-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=20)),
+            end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=16, minute=36)),
             member_only=False,
             location="Common Room",
             organizer=self.organizer,
@@ -74,8 +76,8 @@ class EventsViewTest(TestCase):
             image=get_image_file(),
             description="Member Event description",
             lead="Member Event Lead",
-            start_date_time="2200-01-01 01:20",
-            end_date_time="2200-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=20)),
+            end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=16, minute=36)),
             member_only=True,
             location="Common Room",
             organizer=self.organizer,
@@ -152,8 +154,8 @@ class EventsListViewTest(TestCase):
             image=get_image_file(),
             description="Public Event description",
             lead="Public Event Lead",
-            start_date_time="2200-01-01 01:20",
-            end_date_time="2200-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=20)),
+            end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=16, minute=36)),
             member_only=False,
             location="Common Room",
             organizer=self.organizer,
@@ -165,8 +167,8 @@ class EventsListViewTest(TestCase):
             image=get_image_file(),
             description="Member Event description",
             lead="Member Event Lead",
-            start_date_time="2201-01-01 01:20",
-            end_date_time="2201-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2201, 1, 1, hour=1, minute=20)),
+            end_date_time=make_aware(datetime.datetime(2201, 1, 1, hour=16, minute=36)),
             member_only=True,
             location="Common Room",
             organizer=self.organizer,
@@ -284,8 +286,8 @@ class EventsUpdateViewTest(TestCase):
             image=get_image_file(),
             description="Public Event description",
             lead="Public Event Lead",
-            start_date_time="2200-01-01 01:20",
-            end_date_time="2200-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=30)),
+            end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=16, minute=36)),
             member_only=False,
             location="Common Room",
             organizer=self.organizer,
@@ -348,8 +350,8 @@ class EventsDeleteViewTest(TestCase):
             image=get_image_file(),
             description="Public Event description",
             lead="Public Event Lead",
-            start_date_time="2200-01-01 01:20",
-            end_date_time="2200-01-01 16:36",
+            start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=30)),
+            end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=16, minute=36)),
             member_only=False,
             location="Common Room",
             organizer=self.organizer,
@@ -404,8 +406,8 @@ class EventFormTest(TestCase):
     @staticmethod
     def generate_form(
         name="Name",
-        start_date_time="2200-01-01 01:20",
-        end_date_time="2200-01-01 01:20",
+        start_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=20)),
+        end_date_time=make_aware(datetime.datetime(2200, 1, 1, hour=1, minute=20)),
         image=None,
         member_only=False,
         lead="Lead",


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Fixes the issue that event list and event detail page times were mismatched. Also fixes the warnings in the tests about naive datetimes.
<!--- Add linked issue here if applicable -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
