### PR TITLE
Change TZ toe Europe/Amsterdam for event ical feed

### DIFF
--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -99,7 +99,7 @@ class EventFeed(ICalFeed):
 
     domain = Site.objects.get_current().domain
     product_id = "-//" + domain + "//Events//EN"
-    timezone = "UTC"
+    timezone = "Europe/Amsterdam"
     file_name = "event.ics"
 
     def items(self):


### PR DESCRIPTION
The TZ for the ical feed was still set to UTC from when we used UTC, but that has  since changed