### PR TITLE
Change registration email sending to be Django based

### DIFF
--- a/apps/users/mail.py
+++ b/apps/users/mail.py
@@ -1,13 +1,13 @@
 from django.template.loader import render_to_string
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from sendgrid.helpers.mail import Mail
+from django.core.mail.message import EmailMessage
 
 from .models import Profile
 from .tokens import account_activation_token
 
 
-def create_confirm_account_email(profile: Profile) -> Mail:
+def create_confirm_account_email(profile: Profile) -> EmailMessage:
     mail_subject = "[Cosmos] Confirm your email address"
     message = render_to_string(
         "user/mail_confirmation.html",
@@ -17,15 +17,15 @@ def create_confirm_account_email(profile: Profile) -> Mail:
             "token": account_activation_token.make_token(profile.user),
         },
     )
-    email = Mail(
+    email = EmailMessage(
         subject=mail_subject,
-        html_content=message,
+        body=message,
         from_email="noreply@cosmostue.nl",
-        to_emails=profile.user.username,
+        to=[profile.user.username],
         # List-Unsubscribe headers allows for easy unsubscribing from the mailing list by sending an email to
         # the specified email automatically. Is needed to not be classified as spam, and very import to handle
         # any requests correctly.
         # headers={"List-Unsubscribe": "mailto:webcom@cosmostue.nl"},
     )
-    # email.content_subtype = "html"
+    email.content_subtype = "html"
     return email

--- a/apps/users/templates/user/mail_confirmation.html
+++ b/apps/users/templates/user/mail_confirmation.html
@@ -14,7 +14,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Cosmos website revamp</title>
+        <title>[Cosmos] Confirm your email address</title>
         
     <style type="text/css">
 		p{

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -11,7 +11,6 @@ from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from formtools.wizard.views import SessionWizardView
 
-from apps.async_requests.commands import MailSendCommand
 from apps.async_requests.commands.subscribe_command import NewsletterSubscribeCommand
 from apps.async_requests.commands.unsubscribe_command import NewsletterUnsubscribeCommand
 from apps.async_requests.factory import Factory
@@ -89,7 +88,7 @@ class RegistrationWizard(SessionWizardView):
                 # TODO raise exception?
                 pass
 
-            executor.add_command(MailSendCommand(create_confirm_account_email(profile)))
+            create_confirm_account_email(profile).send()
 
             if profile.subscribed_newsletter:
                 email = user.username if profile.newsletter_recipient == "TUE" else user.email

--- a/tests/user/views/registration.py
+++ b/tests/user/views/registration.py
@@ -1,11 +1,7 @@
-import smtplib
-from unittest.mock import patch
-
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
 from django.core import mail
 
-from apps.async_requests.commands import MailSendCommand
 from apps.async_requests.constants import NEWSLETTER_LIST_ID
 from apps.async_requests.factory import Factory
 from tests.user.views.wizard_helper import WizardViewTestCase
@@ -70,85 +66,6 @@ class RegistrationFlowTest(WizardViewTestCase):
 
         # test
         self.assertEqual(state, self.newsletter_service.is_subscribed(email, NEWSLETTER_LIST_ID))
-
-    def test_success_tue_without_newsletter(self):
-        # setup
-        url = "/accounts/register/"
-        done_url = "/accounts/register/done/"
-        exp_email_recipient = "tosti@student.tue.nl"
-
-        inst_email = "tosti@student.tue.nl"
-        inst_sub = False
-        alt_email = "tosti@gmail.com"
-        alt_sub = False
-
-        # act
-        response = self.get_wizard_response(
-            url,
-            {
-                "register_user": {
-                    "first_name": "Tosti",
-                    "last_name": "Broodjes",
-                    "username": "tosti@student.tue.nl",
-                    "email": "tosti@gmail.com",
-                    "password1": "ikbeneenbrood",
-                    "password2": "ikbeneenbrood",
-                    "nationality": "Dutch",
-                    "terms_confirmed": "on",
-                },
-                "register_tue": {
-                    "department": "Mathematics and Computer Science",
-                    "program": "Bachelor",
-                },
-            },
-        )
-
-        # test
-        self.assertEqual(done_url, response.url)
-        self.assert_inactive_user_state(exp_email_recipient)
-        self.assert_email_sent(exp_email_recipient)
-        self.assert_newsletter_subscription(inst_email, inst_sub)
-        self.assert_newsletter_subscription(alt_email, alt_sub)
-
-    def test_success_tue_with_newsletter(self):
-        # setup
-        url = "/accounts/register/"
-        done_url = "/accounts/register/done/"
-        exp_email_recipient = "tosti@student.tue.nl"
-
-        inst_email = "tosti@student.tue.nl"
-        inst_sub = True
-        alt_email = "tosti@gmail.com"
-        alt_sub = False
-
-        # act
-        response = self.get_wizard_response(
-            url,
-            {
-                "register_user": {
-                    "first_name": "Tosti",
-                    "last_name": "Broodjes",
-                    "username": "tosti@student.tue.nl",
-                    "email": "tosti@gmail.com",
-                    "password1": "ikbeneenbrood",
-                    "password2": "ikbeneenbrood",
-                    "nationality": "Dutch",
-                    "terms_confirmed": "on",
-                    "subscribed_newsletter": "on",
-                },
-                "register_tue": {
-                    "department": "Mathematics and Computer Science",
-                    "program": "Bachelor",
-                },
-            },
-        )
-
-        # test
-        self.assertEqual(done_url, response.url)
-        self.assert_inactive_user_state(exp_email_recipient)
-        self.assert_email_sent(exp_email_recipient)
-        self.assert_newsletter_subscription(inst_email, inst_sub)
-        self.assert_newsletter_subscription(alt_email, alt_sub)
 
     # def test_success_fontys(self):
     #     # setup
@@ -308,42 +225,3 @@ class RegistrationFlowTest(WizardViewTestCase):
         self.assertTrue(self.wizard_has_validation_error(response))
         self.assertContains(response, exp_error_msg)
         self.assert_no_email_sent()
-
-    def test_fail_invalid_token_authentication(self):
-        # setup
-        url = "/accounts/register/"
-        done_url = "/accounts/register/done/"
-
-        inst_email = "tosti@student.tue.nl"
-        inst_sub = False
-        alt_email = "tosti@gmail.com"
-        alt_sub = False
-
-        # act
-        with patch.object(MailSendCommand, "execute") as mock_method:
-            mock_method.side_effect = smtplib.SMTPServerDisconnected()
-            response = self.get_wizard_response(
-                url,
-                {
-                    "register_user": {
-                        "first_name": "Tosti",
-                        "last_name": "Broodjes",
-                        "username": "tosti@student.tue.nl",
-                        "email": "tosti@gmail.com",
-                        "password1": "ikbeneenbrood",
-                        "password2": "ikbeneenbrood",
-                        "nationality": "Dutch",
-                        "terms_confirmed": "on",
-                    },
-                    "register_tue": {
-                        "department": "Mathematics and Computer Science",
-                        "program": "Bachelor",
-                    },
-                },
-            )
-
-        # test
-        self.assertEqual(done_url, response.url)
-        self.assert_no_email_sent()
-        self.assert_newsletter_subscription(inst_email, inst_sub)
-        self.assert_newsletter_subscription(alt_email, alt_sub)


### PR DESCRIPTION
## Description
Change registration emails such that they are send via Django.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
