### PR TITLE
ignore invalid emails for pwd reset

### DIFF
--- a/apps/users/forms/authorization.py
+++ b/apps/users/forms/authorization.py
@@ -87,7 +87,10 @@ class CosmosPasswordResetForm(PasswordResetForm):
 
         # modified
         email = self.cleaned_data["email"]
-        user = User.objects.get(**{"username__iexact": email, "is_active": True})
+        users = User.objects.filter(**{"username__iexact": email, "is_active": True})
+        if len(users) == 0:
+            return
+        user = users[0]
 
         context = {
             "email": user.username,


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
We have a custom password reset class because we store institution email as the username. However, the code throws an exception when it doesn't find a matching email in the DB. The fix ignores queries which gives no valid users.

<!--- Add linked issue here if applicable -->
Fixes #314 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
