### PR TITLE
lock black action to 24.8.0 to fix py3.8 compatibility

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install requirements
         run: pipenv install --deploy --dev
       - name: Run isort
-        run: pipenv run isort **/*.py -c
+      run: pipenv run isort **/*.py -c

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '3.8'
           cache: 'pipenv'
       - name: Run black
-        uses: psf/black@stable
+        uses: psf/black@24.8.0
         with:
           version: "24.8.0"
       - name: Set up pipenv

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install requirements
         run: pipenv install --deploy --dev
       - name: Run isort
-      run: pipenv run isort **/*.py -c
+        run: pipenv run isort **/*.py -c


### PR DESCRIPTION
Fix 'Format' GitHub action after new Black dropped support for running on Python 3.8 and 3.9.

## Description
<!--- Describe your changes -->

<!--- Add linked issue here if applicable -->
Fixes #

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new code is fully covered by tests (see coverage report)
